### PR TITLE
Add remark linter config

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,21 @@
+{
+  "plugins": {
+    "lint": {
+      "final-newline": true,
+      "list-item-bullet-indent": true,
+      "list-item-indent": "tab-size",
+      "no-auto-link-without-protocol": true,
+      "no-blockquote-without-caret": true,
+      "no-literal-urls": true,
+      "ordered-list-marker-style": ".",
+      "hard-break-spaces": true,
+      "no-duplicate-definitions": true,
+      "no-heading-content-indent": true,
+      "no-inline-padding": true,
+      "no-shortcut-reference-image": true,
+      "no-shortcut-reference-link": true,
+      "no-undefined-references": true,
+      "no-unused-definitions": true
+    }
+  }
+}


### PR DESCRIPTION
## Motivation
Remark engine doesn't have a default presets. Due to this, it's not reporting markdown problems, so we need to create one config file in our default linters config files.

## Proposed Solution
I've followed [remark-preset-lint-recommended](https://github.com/remarkjs/remark-lint/tree/master/packages/remark-preset-lint-recommended) presets and create our own remark config file.