### PR TITLE
Update Rubocop config file to follow 0.82

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 AllCops:
   Exclude:
     - 'bin/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,7 +74,7 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Max: 100
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,10 +26,10 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: true
   EnforcedLastArgumentHashStyle: always_ignore
-  
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 Rails:
   Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/CaseIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,10 +48,6 @@ Style/BlockDelimiters:
   Exclude:
     - spec/**/*_spec.rb
 
-Style/BracesAroundHashParameters:
-  Exclude:
-    - spec/**/*_spec.rb
-
 Style/GuardClause:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Layout/ParameterAlignment:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
- Add `rubocop-rails` require (standalone gem now) - [Ref](https://github.com/rubocop-hq/rubocop/blob/v0.82.0/CHANGELOG.md#changes-12)
- Rename `Layout/AlignParameters` to `Layout/ParameterAlignment` - [Ref](https://github.com/rubocop-hq/rubocop/pull/7468)
- Rename `Layout/IndentHash` to `Layout/FirstHashElementIndentation` - [Ref](https://github.com/rubocop-hq/rubocop/blob/v0.82.0/CHANGELOG.md#changes-16) & [Ref](https://github.com/rubocop-hq/rubocop/pull/7468)
- Rename `Layout/AlignHash` to `Layout/HashAlignment` - [Ref](https://github.com/rubocop-hq/rubocop/pull/7468)
- Remove `Style/BracesAroundHashParameters` deprecated cop - [Ref](https://github.com/rubocop-hq/rubocop/blob/v0.82.0/CHANGELOG.md#changes-3)
- Rename `Metrics/LineLength` to `Layout/LineLength` - [Ref](https://github.com/rubocop-hq/rubocop/pull/7542)