### PR TITLE
Add tmp to Rubocop to exclude dirs list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'script/**/*'
+    - 'tmp/**/*'
 
 Rails:
   Enabled: true


### PR DESCRIPTION
`/tmp` directory should not be considered in most applications.