### PR TITLE
Use array notation for rubocop extensions for latest channel

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rails
+require:
+  - rubocop-rails
 
 AllCops:
   Exclude:


### PR DESCRIPTION
We realized that Rubocop was raising `no implicit conversion of String into Array` when using common `require` notation for Rubocop extensions.