### PR TITLE
Change reek PrimaDonnaMethod to MissingSafeMethod

### DIFF
--- a/.defaults.reek
+++ b/.defaults.reek
@@ -24,7 +24,7 @@ IrresponsibleModule:
   enabled: false
 NestedIterators:
   max_allowed_nesting: 2
-PrimaDonnaMethod:
+MissingSafeMethod:
   enabled: false
 UnusedParameters:
   enabled: false


### PR DESCRIPTION
## Motivation

As a user reported the following error:
```
engine reek:stable failed with status 1 and stderr 
You are trying to configure smell type MissingSafeMethod but we can't find one with that name.
Please make sure you spelled it right. (See 'defaults.reek' in the Reek
repository for a list of all available smell types.)
```

the reek detector `PrimaDonnaMethod` was changed to `MissingSafeMethod` in the `v 5.0.0`, [see more](https://github.com/troessner/reek/commit/4550f12a40877ffbafb6316e37b5667bc762a1f2#diff-7f92c5610c3a0e71da81bda87b7ccc779ef41c77acfd731790a87846a1366a89).

## Proposed Solution

Change `PrimaDonnaMethod` to `MissingSafeMethod` in `.defaults.reek`